### PR TITLE
update dependencies (mocha v3.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test-console": "^1.0.0"
   },
   "dependencies": {
-    "mocha": "^2.2.5",
-    "mocha-junit-reporter": "^1.6.1"
+    "mocha": "^3.0.0",
+    "mocha-junit-reporter": "^1.12.0"
   }
 }


### PR DESCRIPTION
A fix for this warning, which is thrown on new installs:

```
npm WARN mocha-junit-reporter@1.11.1 requires a peer of mocha@^2.2.5 but none was installed.
```

Addresses https://github.com/sandcastle/mocha-circleci-reporter/issues/2
