### PR TITLE
Upgrade vulnerable dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-    - "iojs"
-    - "0.12"
-    - "0.11"
-    - "0.10"
+    - "node"
+    - "lts/*"
 matrix:
   fast_finish: true
 sudo: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,269 @@
+{
+  "name": "mocha-circleci-reporter",
+  "version": "0.0.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
+      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "mocha-junit-reporter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.17.0.tgz",
+      "integrity": "sha1-LlFJ7UD8XS48px5C21qx/snG2Fw=",
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "requires": {
+        "has-flag": "^2.0.0"
+      }
+    },
+    "test-console": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/test-console/-/test-console-1.1.0.tgz",
+      "integrity": "sha512-pntCc+DnxNVZxNIul3NjThWaLvIrp9GNHRMrriyFWFtq10LpbHGsagu7riq7UIZn79f9aXnKI7YgyMvf8dcKsg==",
+      "dev": true
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test-console": "^1.0.0"
   },
   "dependencies": {
-    "mocha": "^3.0.0",
-    "mocha-junit-reporter": "^1.12.0"
+    "mocha": "^5.1.1",
+    "mocha-junit-reporter": "^1.17.0"
   }
 }

--- a/test/helpers/mock-runner.js
+++ b/test/helpers/mock-runner.js
@@ -1,39 +1,52 @@
-'use strict';
+"use strict"
 
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
+var EventEmitter = require("events").EventEmitter
+var util = require("util")
 
 // mock test runner
 function Runner() {
-  Runner.super_.call(this);
+  Runner.super_.call(this)
 }
 
-util.inherits(Runner, EventEmitter);
+util.inherits(Runner, EventEmitter)
 
 Runner.prototype.start = function() {
-  this.emit('start');
-};
+  this.emit("start")
+}
 
 Runner.prototype.end = function() {
-  this.emit('end');
-};
+  this.emit("end")
+}
 
 Runner.prototype.startSuite = function(suite) {
-  this.emit('suite', suite);
-};
+  suite.suites = suite.suites || []
+  suite.tests = suite.tests || []
+
+  if (this._currentSuite) {
+    suite.parent = this._currentSuite
+  }
+
+  this._currentSuite = suite
+  this.emit("suite", suite)
+}
 
 Runner.prototype.pass = function(test) {
-  this.emit('pass', test);
-  this.endTest();
-};
+  this.emit("pass", test)
+  this.endTest()
+}
 
 Runner.prototype.fail = function(test, reason) {
-  this.emit('fail', test, reason);
-  this.endTest();
-};
+  this.emit("fail", test, reason)
+  this.endTest()
+}
+
+Runner.prototype.pending = function(test) {
+  this.emit("pending", test)
+  this.endTest()
+}
 
 Runner.prototype.endTest = function() {
-  this.emit('end test');
-};
+  this.emit("end test")
+}
 
-module.exports = Runner;
+module.exports = Runner

--- a/test/helpers/mock-test.js
+++ b/test/helpers/mock-test.js
@@ -1,15 +1,17 @@
-'use strict';
+"use strict"
 
 function Test(fullTitle, title, duration) {
-  
-  this.title = title;
-  this.duration = duration;
-  
-  this.fullTitle = function() { 
-    return fullTitle; 
-  };
-  
-  this.slow = function() { };
+  return {
+    title: title,
+    duration: duration,
+    fullTitle: function() {
+      return fullTitle
+    },
+    titlePath: function() {
+      return [fullTitle]
+    },
+    slow: function() {},
+  }
 }
 
 module.exports = Test

--- a/test/index.js
+++ b/test/index.js
@@ -10,54 +10,56 @@ var fs = require('fs');
 
 
 describe('mocha-circleci-reporter', function() {
-    
+
     var runner;
-    var file = './test/output/console.xml';
-    
+    var file = __dirname + '/output/console.xml';
+
     beforeEach(function() {
         runner = new Runner();
     });
-    
+
     afterEach(function(){
-        fs.unlinkSync(file);
+        if (fs.existsSync(file)) {
+            fs.unlinkSync(file);
+        }
     })
-    
+
     it('should output spec to stdout', function() {
-        
+
         new Reporter(runner, {
-          reporterOptions: { mochaFile: 'test/output/console.xml' }
+          reporterOptions: { mochaFile: file }
         });
-        
+
         var stdout = testConsole.stdout.inspect();
         try{
           executeTestRunner();
         }
-        finally{            
+        finally{
           stdout.restore();
         }
-        
+
         assert(stdout.output[1], '\u001b[0mFoo Bar module\u001b[0m\n');
     });
-    
+
     it('should output junit file', function() {
-        
+
         new Reporter(runner, {
-          reporterOptions: { mochaFile: 'test/output/console.xml' }
+          reporterOptions: { mochaFile: file }
         });
-        
+
         var stdout = testConsole.stdout.inspect();
         try{
           executeTestRunner();
-          
+
           assert(fs.existsSync(file));
         }
-        finally{            
+        finally{
           stdout.restore();
         }
     });
-    
+
     function executeTestRunner(char){
-        
+
         char = char || '';
         runner.start();
 
@@ -65,19 +67,19 @@ describe('mocha-circleci-reporter', function() {
           title: 'Foo Bar module',
           tests: [1, 2]
         });
-        
+
         runner.pass(new Test('Foo can weez the juice', 'can weez the juice', 1));
         runner.fail(new Test('Bar can narfle the garthog', 'can narfle the garthog', 1), {
           message: char + 'expected garthog to be dead' + char
         });
-    
+
         runner.startSuite({
           title: 'Another suite!',
           tests: [1]
         });
         runner.pass(new Test('Another suite', 'works', 4));
-    
+
         runner.end();
     }
-        
+
 });


### PR DESCRIPTION
With the recent release of `npm audit` and automatic dependency security checks it flagged up that this module uses mocha v3, which has a dependency on a package called growl with a critical security flaw: https://nodesecurity.io/advisories/146

I've upgraded all deps to their latest versions and fixed test failures (v4 mocha adds another expected `titlePath` method to `Test` instances).

As part of this I also changed the node versions being checked by Travis to `node` (latest stable) and `lts/*` (latest LTS), because the existing versions were all unsupported.